### PR TITLE
[#3] feat : 로그인 기능 구현

### DIFF
--- a/backend/src/main/java/com/todo/auth/domain/LoginProvider.java
+++ b/backend/src/main/java/com/todo/auth/domain/LoginProvider.java
@@ -1,0 +1,7 @@
+package com.todo.auth.domain;
+
+public enum LoginProvider {
+    SERVER, GOOGLE, KAKAO
+
+    ;
+}

--- a/backend/src/main/java/com/todo/auth/domain/LoginProvider.java
+++ b/backend/src/main/java/com/todo/auth/domain/LoginProvider.java
@@ -1,7 +1,21 @@
 package com.todo.auth.domain;
 
+import static com.todo.common.exception.ErrorCode.UNSUPPORTED_LOGIN_PROVIDER;
+
+import com.todo.auth.exception.AuthenticationException;
+
 public enum LoginProvider {
     SERVER, GOOGLE, KAKAO
 
     ;
+
+    public static LoginProvider from(String provider) {
+        for (LoginProvider value : LoginProvider.values()) {
+            if (value.name().equalsIgnoreCase(provider)) {
+                return value;
+            }
+        }
+        throw new AuthenticationException(UNSUPPORTED_LOGIN_PROVIDER);
+    }
+
 }

--- a/backend/src/main/java/com/todo/auth/domain/LoginUser.java
+++ b/backend/src/main/java/com/todo/auth/domain/LoginUser.java
@@ -1,0 +1,10 @@
+package com.todo.auth.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginUser {
+    private Long userId;
+}

--- a/backend/src/main/java/com/todo/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/todo/auth/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.todo.user.dto;
+package com.todo.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/backend/src/main/java/com/todo/auth/exception/AuthExceptionHandler.java
+++ b/backend/src/main/java/com/todo/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.todo.auth.exception;
+
+import com.todo.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> authenticationExceptionHandler(AuthenticationException e) {
+        log.error("📌인증 예외 발생", e);
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.error(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ErrorResponse> authorizationExceptionHandler(AuthorizationException e) {
+        log.error("📌인가 예외 발생", e);
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.error(e.getErrorCode()));
+    }
+}

--- a/backend/src/main/java/com/todo/auth/exception/AuthenticationException.java
+++ b/backend/src/main/java/com/todo/auth/exception/AuthenticationException.java
@@ -1,0 +1,30 @@
+package com.todo.auth.exception;
+
+import com.todo.common.exception.CustomException;
+import com.todo.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthenticationException extends CustomException {
+    @Override
+    public ErrorCode getErrorCode() {
+        return super.getErrorCode();
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    public AuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthenticationException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public AuthenticationException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/backend/src/main/java/com/todo/auth/exception/AuthorizationException.java
+++ b/backend/src/main/java/com/todo/auth/exception/AuthorizationException.java
@@ -1,0 +1,30 @@
+package com.todo.auth.exception;
+
+import com.todo.common.exception.CustomException;
+import com.todo.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthorizationException extends CustomException {
+    public AuthorizationException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+
+    public AuthorizationException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public AuthorizationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return super.getErrorCode();
+    }
+}

--- a/backend/src/main/java/com/todo/auth/presentaion/AuthController.java
+++ b/backend/src/main/java/com/todo/auth/presentaion/AuthController.java
@@ -1,0 +1,27 @@
+package com.todo.auth.presentaion;
+
+import com.todo.auth.domain.LoginUser;
+import com.todo.auth.dto.LoginRequest;
+import com.todo.auth.service.AuthService;
+import com.todo.common.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public SuccessResponse<LoginUser> login(@RequestParam(required = false) String provider, @RequestBody LoginRequest request){
+        return SuccessResponse.success(HttpStatus.OK, authService.login(provider, request));
+    }
+
+}

--- a/backend/src/main/java/com/todo/auth/presentaion/AuthController.java
+++ b/backend/src/main/java/com/todo/auth/presentaion/AuthController.java
@@ -1,6 +1,6 @@
 package com.todo.auth.presentaion;
 
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.auth.service.AuthService;
 import com.todo.common.response.SuccessResponse;

--- a/backend/src/main/java/com/todo/auth/presentaion/AuthController.java
+++ b/backend/src/main/java/com/todo/auth/presentaion/AuthController.java
@@ -4,6 +4,8 @@ import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.auth.service.AuthService;
 import com.todo.common.response.SuccessResponse;
+import com.todo.common.session.SessionManager;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,10 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final SessionManager sessionManager;
 
     @PostMapping("/login")
-    public SuccessResponse<LoginUser> login(@RequestParam(required = false) String provider, @RequestBody LoginRequest request){
-        return SuccessResponse.success(HttpStatus.OK, authService.login(provider, request));
+    public SuccessResponse<LoginUser> login(
+            @RequestParam(required = false) String provider,
+            @RequestBody LoginRequest loginRequest,
+            HttpServletRequest request
+    ) {
+        LoginUser session = authService.login(provider, loginRequest);
+        sessionManager.create(request, session);
+        return SuccessResponse.success(HttpStatus.OK, session);
     }
 
 }

--- a/backend/src/main/java/com/todo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todo/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.todo.auth.service;
 
 import com.todo.auth.domain.LoginProvider;
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.auth.strategy.AuthStrategy;
 import java.util.List;

--- a/backend/src/main/java/com/todo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todo/auth/service/AuthService.java
@@ -1,0 +1,35 @@
+package com.todo.auth.service;
+
+import com.todo.auth.domain.LoginProvider;
+import com.todo.auth.domain.LoginUser;
+import com.todo.auth.dto.LoginRequest;
+import com.todo.auth.strategy.AuthStrategy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final List<AuthStrategy> authStrategies;
+
+    public LoginUser login(String provider, LoginRequest request) {
+        LoginProvider loginProvider = findAuthProvider(provider);
+
+        return authStrategies.stream()
+                .filter(a -> a.supports(loginProvider))
+                .findFirst()
+                .orElseThrow()
+                .authentication(request);
+    }
+
+    private LoginProvider findAuthProvider(String provider) {
+        if (provider == null) {
+            return LoginProvider.SERVER;
+        }
+        return LoginProvider.from(provider);
+    }
+
+
+}

--- a/backend/src/main/java/com/todo/auth/strategy/AuthStrategy.java
+++ b/backend/src/main/java/com/todo/auth/strategy/AuthStrategy.java
@@ -1,7 +1,7 @@
 package com.todo.auth.strategy;
 
 import com.todo.auth.domain.LoginProvider;
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 
 public interface AuthStrategy {

--- a/backend/src/main/java/com/todo/auth/strategy/AuthStrategy.java
+++ b/backend/src/main/java/com/todo/auth/strategy/AuthStrategy.java
@@ -1,0 +1,9 @@
+package com.todo.auth.strategy;
+
+import com.todo.auth.domain.LoginProvider;
+import com.todo.auth.dto.LoginRequest;
+
+public interface AuthStrategy {
+    boolean supports(LoginProvider provider);
+    Object authentication(LoginRequest request);
+}

--- a/backend/src/main/java/com/todo/auth/strategy/AuthStrategy.java
+++ b/backend/src/main/java/com/todo/auth/strategy/AuthStrategy.java
@@ -1,9 +1,10 @@
 package com.todo.auth.strategy;
 
 import com.todo.auth.domain.LoginProvider;
+import com.todo.auth.domain.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 
 public interface AuthStrategy {
     boolean supports(LoginProvider provider);
-    Object authentication(LoginRequest request);
+    LoginUser authentication(LoginRequest request);
 }

--- a/backend/src/main/java/com/todo/auth/strategy/PasswordAuthStrategy.java
+++ b/backend/src/main/java/com/todo/auth/strategy/PasswordAuthStrategy.java
@@ -3,7 +3,7 @@ package com.todo.auth.strategy;
 import static com.todo.common.exception.ErrorCode.LOGIN_FAIL;
 
 import com.todo.auth.domain.LoginProvider;
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.user.domain.User;
 import com.todo.user.exception.UserException;

--- a/backend/src/main/java/com/todo/auth/strategy/PasswordAuthStrategy.java
+++ b/backend/src/main/java/com/todo/auth/strategy/PasswordAuthStrategy.java
@@ -1,0 +1,41 @@
+package com.todo.auth.strategy;
+
+import static com.todo.common.exception.ErrorCode.LOGIN_FAIL;
+
+import com.todo.auth.domain.LoginProvider;
+import com.todo.auth.domain.LoginUser;
+import com.todo.auth.dto.LoginRequest;
+import com.todo.user.domain.User;
+import com.todo.user.exception.UserException;
+import com.todo.user.service.UserDomainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PasswordAuthStrategy implements AuthStrategy{
+
+    private final UserDomainService userDomainService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public boolean supports(LoginProvider provider) {
+        return provider == LoginProvider.SERVER;
+    }
+
+    @Override
+    public LoginUser authentication(LoginRequest request) {
+        final String email = request.getEmail();
+        final String password = request.getPassword();
+
+        User findUser = userDomainService.findUserByEmail(email);
+        if (!(passwordEncoder.matches(password, findUser.getPassword()))) {
+            throw new UserException(LOGIN_FAIL);
+        }
+
+        return new LoginUser(findUser.getId());
+    }
+}

--- a/backend/src/main/java/com/todo/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todo/common/exception/ErrorCode.java
@@ -14,6 +14,13 @@ public enum ErrorCode {
     UNSUPPORTED_LOGIN_PROVIDER(HttpStatus.BAD_REQUEST, "A01", "지원하지 않는 로그인 제공자입니다."),
 
     /**
+     * 인가 관련 에러
+     */
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "U01", "인증이 필요합니다."),
+
+
+
+    /**
      * 사용자 관련 에러
      */
     EMAIL_NOT_UNIQUE(HttpStatus.BAD_REQUEST, "U01", "이미 사용중인 이메일입니다."),

--- a/backend/src/main/java/com/todo/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todo/common/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
      * 사용자 관련 에러
      */
     EMAIL_NOT_UNIQUE(HttpStatus.BAD_REQUEST, "U01", "이미 사용중인 이메일입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U02", "비밀번호가 일치하지 않습니다.")
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U02", "비밀번호가 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U03", "해당 사용자를 찾을 수 없습니다."),
+    LOGIN_FAIL(HttpStatus.BAD_REQUEST, "U04", "이메일 또는 아이디가 일치하지 않습니다.")
 
     ;
 

--- a/backend/src/main/java/com/todo/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todo/common/exception/ErrorCode.java
@@ -9,6 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     /**
+     * 인증 관련 에러
+     */
+    UNSUPPORTED_LOGIN_PROVIDER(HttpStatus.BAD_REQUEST, "A01", "지원하지 않는 로그인 제공자입니다."),
+
+    /**
      * 사용자 관련 에러
      */
     EMAIL_NOT_UNIQUE(HttpStatus.BAD_REQUEST, "U01", "이미 사용중인 이메일입니다."),

--- a/backend/src/main/java/com/todo/common/session/LoginUser.java
+++ b/backend/src/main/java/com/todo/common/session/LoginUser.java
@@ -1,4 +1,4 @@
-package com.todo.auth.domain;
+package com.todo.common.session;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/todo/common/session/SessionManager.java
+++ b/backend/src/main/java/com/todo/common/session/SessionManager.java
@@ -1,0 +1,43 @@
+package com.todo.common.session;
+
+import com.todo.auth.exception.AuthorizationException;
+import com.todo.common.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SessionManager {
+
+    public static final String USER_SESSION = "userSession";
+    public static final int MAX_INACTIVE_INTERVAL_SECONDS = 1800;
+
+    public void create(HttpServletRequest request, LoginUser user) {
+        HttpSession old = request.getSession(false);
+        if (old != null) {
+            old.invalidate();
+        }
+
+        HttpSession session = request.getSession(true);
+        session.setAttribute(USER_SESSION, user);
+        session.setMaxInactiveInterval(MAX_INACTIVE_INTERVAL_SECONDS);
+    }
+
+    public LoginUser getUserSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null || session.getAttribute(USER_SESSION) == null) {
+            throw new AuthorizationException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return (LoginUser) session.getAttribute(USER_SESSION);
+    }
+
+    public void invalidate(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+    }
+
+}

--- a/backend/src/main/java/com/todo/user/domain/repository/UserRepository.java
+++ b/backend/src/main/java/com/todo/user/domain/repository/UserRepository.java
@@ -1,10 +1,16 @@
 package com.todo.user.domain.repository;
 
 import com.todo.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findUserById(Long id);
+
     @Query("""
     SELECT CASE
                WHEN COUNT(u) > 0 THEN TRUE

--- a/backend/src/main/java/com/todo/user/domain/repository/UserRepository.java
+++ b/backend/src/main/java/com/todo/user/domain/repository/UserRepository.java
@@ -4,12 +4,14 @@ import com.todo.user.domain.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.id = :id")
     Optional<User> findUserById(Long id);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findUserByEmail(String email);
 
     @Query("""
     SELECT CASE

--- a/backend/src/main/java/com/todo/user/dto/LoginRequest.java
+++ b/backend/src/main/java/com/todo/user/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.todo.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/backend/src/main/java/com/todo/user/presentation/UserController.java
+++ b/backend/src/main/java/com/todo/user/presentation/UserController.java
@@ -2,7 +2,7 @@ package com.todo.user.presentation;
 
 import com.todo.common.response.SuccessResponse;
 import com.todo.user.dto.SignupRequest;
-import com.todo.user.service.UserService;
+import com.todo.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,11 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/users")
 public class UserController {
 
-    private final UserService userService;
+    private final UserQueryService userQueryService;
 
     @PostMapping
     public SuccessResponse<Long> signup(@RequestBody SignupRequest request) {
-        return SuccessResponse.success(HttpStatus.CREATED, userService.signup(request));
+        return SuccessResponse.success(HttpStatus.CREATED, userQueryService.signup(request));
     }
 
 }

--- a/backend/src/main/java/com/todo/user/service/UserDomainService.java
+++ b/backend/src/main/java/com/todo/user/service/UserDomainService.java
@@ -1,21 +1,32 @@
 package com.todo.user.service;
 
-import com.todo.common.exception.ErrorCode;
+import static com.todo.common.exception.ErrorCode.USER_NOT_FOUND;
+
 import com.todo.user.domain.User;
 import com.todo.user.domain.repository.UserRepository;
 import com.todo.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class UserDomainService {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public User findUserById(Long id) {
         return userRepository
                 .findUserById(id)
-                .orElseThrow(() -> new UserException(ErrorCode.EMAIL_NOT_UNIQUE));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
+
+    public User findUserByEmail(String email) {
+        return userRepository
+                .findUserByEmail(email)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    }
+
 }

--- a/backend/src/main/java/com/todo/user/service/UserDomainService.java
+++ b/backend/src/main/java/com/todo/user/service/UserDomainService.java
@@ -1,0 +1,21 @@
+package com.todo.user.service;
+
+import com.todo.common.exception.ErrorCode;
+import com.todo.user.domain.User;
+import com.todo.user.domain.repository.UserRepository;
+import com.todo.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDomainService {
+
+    private final UserRepository userRepository;
+
+    public User findUserById(Long id) {
+        return userRepository
+                .findUserById(id)
+                .orElseThrow(() -> new UserException(ErrorCode.EMAIL_NOT_UNIQUE));
+    }
+}

--- a/backend/src/main/java/com/todo/user/service/UserQueryService.java
+++ b/backend/src/main/java/com/todo/user/service/UserQueryService.java
@@ -3,7 +3,6 @@ package com.todo.user.service;
 import static com.todo.common.exception.ErrorCode.EMAIL_NOT_UNIQUE;
 import static com.todo.common.exception.ErrorCode.PASSWORD_MISMATCH;
 
-import com.todo.common.exception.ErrorCode;
 import com.todo.user.domain.User;
 import com.todo.user.domain.repository.UserRepository;
 import com.todo.user.dto.SignupRequest;
@@ -15,7 +14,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class UserService {
+public class UserQueryService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;

--- a/backend/src/test/java/com/todo/auth/presentaion/AuthControllerTest.java
+++ b/backend/src/test/java/com/todo/auth/presentaion/AuthControllerTest.java
@@ -1,0 +1,53 @@
+package com.todo.auth.presentaion;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todo.auth.domain.LoginUser;
+import com.todo.auth.dto.LoginRequest;
+import com.todo.auth.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    AuthService authService;
+
+    @Test
+    void 로그인_성공시_세션정보를_반환한다() throws Exception {
+        //given
+        LoginRequest req = new LoginRequest("user@gmail.com", "rawPassword");
+
+        when(authService.login(null, req)).thenReturn(new LoginUser(1L));
+
+        //when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+}

--- a/backend/src/test/java/com/todo/auth/presentaion/AuthControllerTest.java
+++ b/backend/src/test/java/com/todo/auth/presentaion/AuthControllerTest.java
@@ -1,6 +1,5 @@
 package com.todo.auth.presentaion;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -8,10 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.auth.service.AuthService;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/backend/src/test/java/com/todo/auth/presentaion/AuthControllerTest.java
+++ b/backend/src/test/java/com/todo/auth/presentaion/AuthControllerTest.java
@@ -1,5 +1,7 @@
 package com.todo.auth.presentaion;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -10,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.auth.service.AuthService;
+import com.todo.common.session.SessionManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -29,6 +32,9 @@ class AuthControllerTest {
     ObjectMapper objectMapper;
 
     @MockitoBean
+    SessionManager sessionManager;
+
+    @MockitoBean
     AuthService authService;
 
     @Test
@@ -36,6 +42,7 @@ class AuthControllerTest {
         //given
         LoginRequest req = new LoginRequest("user@gmail.com", "rawPassword");
 
+        doNothing().when(sessionManager).create(any(), any());
         when(authService.login(null, req)).thenReturn(new LoginUser(1L));
 
         //when & then

--- a/backend/src/test/java/com/todo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/todo/auth/service/AuthServiceTest.java
@@ -1,0 +1,122 @@
+package com.todo.auth.service;
+
+import static com.todo.common.exception.ErrorCode.LOGIN_FAIL;
+import static com.todo.common.exception.ErrorCode.UNSUPPORTED_LOGIN_PROVIDER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.auth.domain.LoginProvider;
+import com.todo.auth.domain.LoginUser;
+import com.todo.auth.dto.LoginRequest;
+import com.todo.auth.exception.AuthenticationException;
+import com.todo.auth.strategy.AuthStrategy;
+import com.todo.user.domain.User;
+import com.todo.user.exception.UserException;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Spy
+    List<AuthStrategy> authStrategies = new ArrayList<>();
+
+    @Mock
+    AuthStrategy passwordAuthStrategy;
+
+    @InjectMocks
+    AuthService authService;
+
+    User user;
+    String email;
+    String password;
+
+    @BeforeEach
+    void beforeEach() {
+        this.email = "user@gmail.com";
+        this.password = "rawPassword";
+
+        this.user = User.builder()
+                .id(1L)
+                .email(email)
+                .password(password)
+                .build();
+
+        authStrategies.clear();
+        authStrategies.add(passwordAuthStrategy);
+    }
+
+    @Test
+    @DisplayName("Provider의 값이 null인 경우 기본으로 PasswordAuthStrategy가 선택되어 인증을 수행한다.")
+    void 기본_서버_전략_선택() {
+        //given
+        LoginRequest request = new LoginRequest(email, password);
+
+        when(passwordAuthStrategy.supports(LoginProvider.SERVER)).thenReturn(true);
+
+        //when
+        authService.login(null, request);
+
+        //then
+        verify(passwordAuthStrategy).authentication(request);
+    }
+
+    @Test
+    @DisplayName("서버에서 지원하지 않은 전략인 경우 예외가 발생한다.")
+    void 지원되지_않은_전략() {
+        //given
+        LoginRequest request = new LoginRequest(email, password);
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> authService.login("not", request))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessage(UNSUPPORTED_LOGIN_PROVIDER.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인이 성공하면 사용자의 세션 정보를 반환한다.")
+    void 로그인_성공() {
+        //given
+        LoginRequest request = new LoginRequest(email, password);
+
+        LoginUser stub = new LoginUser(1L);
+
+        when(passwordAuthStrategy.supports(LoginProvider.SERVER)).thenReturn(true);
+        when(passwordAuthStrategy.authentication(any())).thenReturn(stub);
+
+        //when
+        LoginUser session = authService.login(null, request);
+
+        //then
+        assertThat(session.getUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("이메일 또는 패스워드가 일치하지 않으면 예외가 발생한다.")
+    void 로그인_실패_패스워드_이메일_불일치() {
+        //given
+        LoginRequest request = new LoginRequest(email, password);
+
+        when(passwordAuthStrategy.supports(LoginProvider.SERVER)).thenReturn(true);
+        when(passwordAuthStrategy.authentication(any())).thenThrow(new UserException(LOGIN_FAIL));
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> authService.login(null, request))
+                .isInstanceOf(UserException.class)
+                .hasMessage(LOGIN_FAIL.getMessage());
+
+    }
+
+}

--- a/backend/src/test/java/com/todo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/todo/auth/service/AuthServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.todo.auth.domain.LoginProvider;
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.auth.exception.AuthenticationException;
 import com.todo.auth.strategy.AuthStrategy;

--- a/backend/src/test/java/com/todo/auth/strategy/PasswordAuthStrategyTest.java
+++ b/backend/src/test/java/com/todo/auth/strategy/PasswordAuthStrategyTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.todo.auth.domain.LoginProvider;
-import com.todo.auth.domain.LoginUser;
+import com.todo.common.session.LoginUser;
 import com.todo.auth.dto.LoginRequest;
 import com.todo.common.exception.ErrorCode;
 import com.todo.user.domain.User;

--- a/backend/src/test/java/com/todo/auth/strategy/PasswordAuthStrategyTest.java
+++ b/backend/src/test/java/com/todo/auth/strategy/PasswordAuthStrategyTest.java
@@ -1,0 +1,98 @@
+package com.todo.auth.strategy;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.todo.auth.domain.LoginProvider;
+import com.todo.auth.domain.LoginUser;
+import com.todo.auth.dto.LoginRequest;
+import com.todo.common.exception.ErrorCode;
+import com.todo.user.domain.User;
+import com.todo.user.exception.UserException;
+import com.todo.user.service.UserDomainService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordAuthStrategyTest {
+
+    @Mock
+    UserDomainService userDomainService;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    PasswordAuthStrategy passwordAuthStrategy;
+
+    User user;
+    String email;
+    String password;
+
+    @BeforeEach
+    void beforeEach() {
+        this.email = "user@gmail.com";
+        this.password = "rawPassword";
+        this.user = User.builder()
+                .id(1L)
+                .email(email)
+                .password(password)
+                .build();
+    }
+
+    @Test
+    @DisplayName("PasswordAuthStrategy는 SERVER 로그인 방식을 지원한다")
+    void 서버_로그인_방식을_지원한다() {
+        //given
+        LoginProvider provider = LoginProvider.SERVER;
+
+        //when
+        boolean supports = passwordAuthStrategy.supports(provider);
+
+        //then
+        assertThat(supports).isTrue();
+    }
+
+    @Test
+    @DisplayName("DB에 저장된 이메일과 비밀번호가 일치할 경우 로그인은 성공한다.")
+    void 패스워드기반_로그인_성공() {
+        //given
+        LoginRequest request = new LoginRequest(email, password);
+
+        when(userDomainService.findUserByEmail(email)).thenReturn(user);
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+
+        //when
+        LoginUser loginUser = passwordAuthStrategy.authentication(request);
+
+        //then
+        assertThat(loginUser.getUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("패스워드 불일치시에는 예외가 발생한다.")
+    void 패스워드기반_로그인_실패_패스워드_불일치() {
+        //given
+        LoginRequest request = new LoginRequest(email, password);
+
+        when(userDomainService.findUserByEmail(email)).thenReturn(user);
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> passwordAuthStrategy.authentication(request))
+                .isInstanceOf(UserException.class)
+                .hasMessage(ErrorCode.LOGIN_FAIL.getMessage());
+    }
+
+
+
+
+}

--- a/backend/src/test/java/com/todo/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/com/todo/user/presentation/UserControllerTest.java
@@ -1,21 +1,17 @@
 package com.todo.user.presentation;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.common.exception.ErrorCode;
-import com.todo.user.domain.User;
 import com.todo.user.dto.SignupRequest;
 import com.todo.user.exception.UserException;
-import com.todo.user.service.UserService;
+import com.todo.user.service.UserQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +32,7 @@ class UserControllerTest {
     ObjectMapper objectMapper;
 
     @MockitoBean
-    UserService userService;
+    UserQueryService userQueryService;
 
     String email;
     String password;
@@ -53,7 +49,7 @@ class UserControllerTest {
     void 회원가입_성공() throws Exception {
         //given
         SignupRequest request = new SignupRequest(email, password, confirmPassword);
-        when(userService.signup(any())).thenReturn(1L);
+        when(userQueryService.signup(any())).thenReturn(1L);
 
         //when & then
         mockMvc.perform(post("/api/users")
@@ -70,7 +66,7 @@ class UserControllerTest {
     void 회원가입_실패() throws Exception {
         //given
         SignupRequest request = new SignupRequest(email, password, confirmPassword);
-        when(userService.signup(any())).thenThrow(new UserException(ErrorCode.EMAIL_NOT_UNIQUE));
+        when(userQueryService.signup(any())).thenThrow(new UserException(ErrorCode.EMAIL_NOT_UNIQUE));
 
         //when & then
         mockMvc.perform(post("/api/users")

--- a/backend/src/test/java/com/todo/user/service/UserQueryServiceTest.java
+++ b/backend/src/test/java/com/todo/user/service/UserQueryServiceTest.java
@@ -2,12 +2,10 @@ package com.todo.user.service;
 
 import static com.todo.common.exception.ErrorCode.EMAIL_NOT_UNIQUE;
 import static com.todo.common.exception.ErrorCode.PASSWORD_MISMATCH;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.todo.common.exception.ErrorCode;
 import com.todo.user.domain.User;
 import com.todo.user.domain.repository.UserRepository;
 import com.todo.user.dto.SignupRequest;
@@ -25,7 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
-class UserServiceTest {
+class UserQueryServiceTest {
 
     @Mock
     UserRepository userRepository;
@@ -37,7 +35,7 @@ class UserServiceTest {
     PasswordEncoder passwordEncoder;
 
     @InjectMocks
-    UserService userService;
+    UserQueryService userQueryService;
 
     User user;
     String email;
@@ -67,7 +65,7 @@ class UserServiceTest {
         when(userMapper.signupRequestToEntity(any())).thenReturn(user);
 
         //when
-        Long userId = userService.signup(req);
+        Long userId = userQueryService.signup(req);
 
         //then
         Assertions.assertThat(userId).isEqualTo(1L);
@@ -83,7 +81,7 @@ class UserServiceTest {
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
 
         //when
-        userService.signup(req);
+        userQueryService.signup(req);
 
         //then
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
@@ -103,7 +101,7 @@ class UserServiceTest {
         when(userRepository.existsByEmail(email)).thenReturn(true);
 
         //when & then
-        Assertions.assertThatThrownBy(() -> userService.signup(req))
+        Assertions.assertThatThrownBy(() -> userQueryService.signup(req))
                 .isInstanceOf(UserException.class)
                 .hasMessage(EMAIL_NOT_UNIQUE.getMessage());
     }
@@ -115,7 +113,7 @@ class UserServiceTest {
         SignupRequest req = new SignupRequest(email, password, "wrongPassword");
 
         //when & then
-        Assertions.assertThatThrownBy(() -> userService.signup(req))
+        Assertions.assertThatThrownBy(() -> userQueryService.signup(req))
                 .isInstanceOf(UserException.class)
                 .hasMessage(PASSWORD_MISMATCH.getMessage());
     }


### PR DESCRIPTION
### 목표
- 사용자는 이메일과 비밀번호를 기반으로 로그인을 할 수 있다.

### 구현 목록

- [x] 로그인 요청 DTO 생성
- [x] 로그인 로직 구현
- [x] 테스트 코드 작성
- [x] 로그인 API 엔드 포인트 추가 `POST /api/login`
- [x] 세션 관리 객체 및 기능 구현
- [x] 인증 & 인가 예외 추가 및 예외 핸들러 추가   