### PR TITLE
[#7] feat : Todo 기능 구현

### DIFF
--- a/backend/src/main/java/com/todo/cateogry/domain/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/todo/cateogry/domain/repository/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.todo.cateogry.domain.repository;
 
 import com.todo.cateogry.domain.Category;
+import com.todo.user.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT c FROM Category c WHERE c.id = :id")
     Optional<Category> findCategoryById(Long id);
+
+    @Query("SELECT c FROM Category c WHERE c.id = :id AND c.user.id = :userId")
+    Optional<Category> findCategoryByIdAndUserId(Long id, Long userId);
+
 }

--- a/backend/src/main/java/com/todo/cateogry/service/CategoryQueryService.java
+++ b/backend/src/main/java/com/todo/cateogry/service/CategoryQueryService.java
@@ -37,4 +37,9 @@ public class CategoryQueryService {
                 .findCategoryById(categoryId)
                 .orElseThrow(() -> new CategoryException(CATEGORY_NOT_FOUND));
     }
+
+    public Category findByIdAndUserId(Long categoryId, Long userId) {
+        return categoryRepository.findCategoryByIdAndUserId(categoryId, userId)
+                .orElseThrow(() -> new CategoryException(CATEGORY_NOT_FOUND));
+    }
 }

--- a/backend/src/main/java/com/todo/common/config/QueryDslConfig.java
+++ b/backend/src/main/java/com/todo/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.todo.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/backend/src/main/java/com/todo/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todo/common/exception/ErrorCode.java
@@ -25,8 +25,11 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "C01", "카테고리를 찾을 수 없습니다."),
     CATEGORY_UPDATE_FORBIDDEN(HttpStatus.BAD_REQUEST, "C02", "본인의 카테고리만 수정할 수 있습니다."),
 
-
-
+    /**
+     * Task 관련 에러
+     */
+    TASK_NOT_FOUND(HttpStatus.BAD_REQUEST, "T01", "해당 Task를 찾을 수 없습니다."),
+    TASK_ACCESS_FORBIDDEN(HttpStatus.BAD_REQUEST, "T02", "해당 Task의 접근 권한이 없습니다."),
 
 
     /**

--- a/backend/src/main/java/com/todo/task/dto/TaskCreateRequest.java
+++ b/backend/src/main/java/com/todo/task/dto/TaskCreateRequest.java
@@ -1,0 +1,15 @@
+package com.todo.task.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TaskCreateRequest {
+    private String title;
+    private String content;
+    private String status;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/backend/src/main/java/com/todo/task/dto/TaskResponse.java
+++ b/backend/src/main/java/com/todo/task/dto/TaskResponse.java
@@ -1,16 +1,17 @@
 package com.todo.task.dto;
 
+import com.todo.task.entity.TaskStatus;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class TaskCreateRequest {
+public class TaskResponse {
     private Long categoryId;
     private String title;
     private String content;
-    private String status;
+    private TaskStatus status;
     private LocalDate startDate;
     private LocalDate endDate;
 }

--- a/backend/src/main/java/com/todo/task/dto/TaskSearchRequest.java
+++ b/backend/src/main/java/com/todo/task/dto/TaskSearchRequest.java
@@ -1,0 +1,14 @@
+package com.todo.task.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TaskSearchRequest {
+    private Long categoryId;
+    private String status;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/backend/src/main/java/com/todo/task/dto/TaskUpdateRequest.java
+++ b/backend/src/main/java/com/todo/task/dto/TaskUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.todo.task.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TaskUpdateRequest {
+    private Long taskId;
+    private String title;
+    private String content;
+    private String status;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/backend/src/main/java/com/todo/task/entity/Task.java
+++ b/backend/src/main/java/com/todo/task/entity/Task.java
@@ -1,6 +1,9 @@
 package com.todo.task.entity;
 
+import static com.todo.common.exception.ErrorCode.TASK_ACCESS_FORBIDDEN;
+
 import com.todo.cateogry.domain.Category;
+import com.todo.task.exception.TaskException;
 import com.todo.user.domain.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -48,4 +51,32 @@ public class Task {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void validateOwner(Long userId) {
+        if (!(this.user.getId().equals(userId))) {
+            throw new TaskException(TASK_ACCESS_FORBIDDEN);
+        }
+    }
+
+    public void taskUpdate(String title, String content, LocalDate startDate, LocalDate endDate, String status) {
+        if (title != null) {
+            this.title = title;
+        }
+
+        if (content != null) {
+            this.content = content;
+        }
+
+        if (startDate != null) {
+            this.startDate = startDate;
+        }
+
+        if (endDate != null) {
+            this.endDate = endDate;
+        }
+
+        if (status != null) {
+            this.status = TaskStatus.from(status);
+        }
+    }
 }

--- a/backend/src/main/java/com/todo/task/entity/Task.java
+++ b/backend/src/main/java/com/todo/task/entity/Task.java
@@ -13,8 +13,10 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
 @Entity
 @NoArgsConstructor

--- a/backend/src/main/java/com/todo/task/entity/Task.java
+++ b/backend/src/main/java/com/todo/task/entity/Task.java
@@ -1,0 +1,46 @@
+package com.todo.task.entity;
+
+import com.todo.cateogry.domain.Category;
+import com.todo.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    private TaskStatus status;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/backend/src/main/java/com/todo/task/entity/Task.java
+++ b/backend/src/main/java/com/todo/task/entity/Task.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Builder
@@ -38,10 +39,12 @@ public class Task {
     @Enumerated(EnumType.STRING)
     private TaskStatus status;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "category_id")
     private Category category;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;

--- a/backend/src/main/java/com/todo/task/entity/TaskStatus.java
+++ b/backend/src/main/java/com/todo/task/entity/TaskStatus.java
@@ -1,0 +1,5 @@
+package com.todo.task.entity;
+
+public enum TaskStatus {
+    NONE, PROGRESS, DONE
+}

--- a/backend/src/main/java/com/todo/task/entity/TaskStatus.java
+++ b/backend/src/main/java/com/todo/task/entity/TaskStatus.java
@@ -1,5 +1,15 @@
 package com.todo.task.entity;
 
 public enum TaskStatus {
-    NONE, PROGRESS, DONE
+    NONE, PROGRESS, DONE;
+
+
+    public static TaskStatus from(String status) {
+        for (TaskStatus value : TaskStatus.values()) {
+            if (value.name().equalsIgnoreCase(status)) {
+                return value;
+            }
+        }
+        return null;
+    }
 }

--- a/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
+++ b/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
@@ -1,7 +1,11 @@
 package com.todo.task.entity.repository;
 
 import com.todo.task.entity.Task;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+    @Query("SELECT t FROM Task t WHERE T.id = :taskId")
+    Optional<Task> findTaskById(Long taskId);
 }

--- a/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
+++ b/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TaskRepository extends JpaRepository<Task, Long>, TaskRepositoryCustom{
-    @Query("SELECT t FROM Task t WHERE T.id = :taskId")
+    @Query("SELECT t FROM Task t WHERE t.id = :taskId")
     Optional<Task> findTaskById(Long taskId);
 }

--- a/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
+++ b/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface TaskRepository extends JpaRepository<Task, Long> {
+public interface TaskRepository extends JpaRepository<Task, Long>, TaskRepositoryCustom{
     @Query("SELECT t FROM Task t WHERE T.id = :taskId")
     Optional<Task> findTaskById(Long taskId);
 }

--- a/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
+++ b/backend/src/main/java/com/todo/task/entity/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package com.todo.task.entity.repository;
+
+import com.todo.task.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/backend/src/main/java/com/todo/task/entity/repository/TaskRepositoryCustom.java
+++ b/backend/src/main/java/com/todo/task/entity/repository/TaskRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.todo.task.entity.repository;
+
+import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TaskRepositoryCustom {
+    List<Task> search(Long memberId, Long categoryId, LocalDate from, LocalDate to, TaskStatus status);
+}

--- a/backend/src/main/java/com/todo/task/entity/repository/TaskRepositoryImpl.java
+++ b/backend/src/main/java/com/todo/task/entity/repository/TaskRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.todo.task.entity.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.todo.task.entity.QTask;
+import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TaskRepositoryImpl implements TaskRepositoryCustom{
+
+    private final JPAQueryFactory qf;
+
+    @Override
+    public List<Task> search(Long memberId, Long categoryId, LocalDate from, LocalDate to, TaskStatus status) {
+        QTask t = QTask.task;
+
+        BooleanBuilder where = new BooleanBuilder().and(t.user.id.eq(memberId));
+
+        if (categoryId != null) where.and(t.category.id.eq(categoryId));
+        if (status != null)     where.and(t.status.eq(status));
+        if (from != null)       where.and(t.startDate.goe(from));
+        if (to != null)         where.and(t.endDate.loe(to));
+
+        return qf.selectFrom(t)
+                .leftJoin(t.category).fetchJoin()
+                .where(where)
+                .orderBy(t.startDate.asc(), t.id.desc())
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/todo/task/exception/TaskException.java
+++ b/backend/src/main/java/com/todo/task/exception/TaskException.java
@@ -1,0 +1,30 @@
+package com.todo.task.exception;
+
+import com.todo.common.exception.CustomException;
+import com.todo.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TaskException extends CustomException {
+    public TaskException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+
+    public TaskException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public TaskException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return super.getErrorCode();
+    }
+}

--- a/backend/src/main/java/com/todo/task/exception/TaskExceptionHandler.java
+++ b/backend/src/main/java/com/todo/task/exception/TaskExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.todo.task.exception;
+
+import com.todo.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class TaskExceptionHandler {
+
+    @ExceptionHandler(TaskException.class)
+    public ResponseEntity<ErrorResponse> taskExceptionHandler(TaskException e) {
+        log.error("📌Task Exception : ", e);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.error(e.getErrorCode()));
+    }
+
+}

--- a/backend/src/main/java/com/todo/task/mapper/TaskMapper.java
+++ b/backend/src/main/java/com/todo/task/mapper/TaskMapper.java
@@ -1,0 +1,31 @@
+package com.todo.task.mapper;
+
+import com.todo.cateogry.domain.Category;
+import com.todo.task.dto.TaskCreateRequest;
+import com.todo.task.dto.TaskResponse;
+import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = "spring")
+public interface TaskMapper {
+
+    @Mapping(target = "status", source = "status", qualifiedByName = "stringToTaskStatus")
+    Task taskCreateRequestToEntity(TaskCreateRequest request);
+
+    @Mapping(target = "categoryId", source = "category", qualifiedByName = "getCategoryId")
+    TaskResponse entityToTaskResponse(Task task);
+
+    @Named("getCategoryId")
+    default Long getCategoryId(Category category) {
+        return category.getId();
+    }
+
+    @Named("stringToTaskStatus")
+    default TaskStatus stringToTaskStatus(String status) {
+        if (status == null) return TaskStatus.NONE;
+        return TaskStatus.from(status);
+    }
+}

--- a/backend/src/main/java/com/todo/task/presentation/TaskController.java
+++ b/backend/src/main/java/com/todo/task/presentation/TaskController.java
@@ -1,0 +1,63 @@
+package com.todo.task.presentation;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.todo.common.response.SuccessResponse;
+import com.todo.common.session.LoginUser;
+import com.todo.common.session.resolver.Login;
+import com.todo.task.dto.TaskCreateRequest;
+import com.todo.task.dto.TaskResponse;
+import com.todo.task.dto.TaskSearchRequest;
+import com.todo.task.dto.TaskUpdateRequest;
+import com.todo.task.service.TaskCommandService;
+import com.todo.task.service.TaskQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/task")
+@RequiredArgsConstructor
+public class TaskController {
+
+    private final TaskQueryService taskQueryService;
+    private final TaskCommandService taskCommandService;
+
+    @PostMapping
+    public SuccessResponse<TaskResponse> createTask(
+            @Login LoginUser loginUser,
+            @RequestBody TaskCreateRequest request
+    ) {
+        return SuccessResponse.success(CREATED, taskCommandService.createTask(loginUser.getUserId(), request));
+    }
+
+    @GetMapping
+    public SuccessResponse<List<TaskResponse>> findTask(
+            @Login LoginUser loginUser,
+            @ModelAttribute TaskSearchRequest request
+    ) {
+        return SuccessResponse.success(HttpStatus.OK, taskQueryService.findAll(loginUser.getUserId(), request));
+    }
+
+    @PutMapping
+    public SuccessResponse<TaskResponse> updateTask(@Login LoginUser loginUser, @RequestBody TaskUpdateRequest request) {
+       return SuccessResponse.success(HttpStatus.OK, taskCommandService.updateTask(loginUser.getUserId(), request));
+    }
+
+    @DeleteMapping
+    public SuccessResponse<Void> DeleteTask(@Login LoginUser loginUser, @RequestParam Long taskId) {
+        taskCommandService.deleteTask(loginUser.getUserId(), taskId);
+        return SuccessResponse.success(HttpStatus.OK);
+    }
+
+}

--- a/backend/src/main/java/com/todo/task/service/TaskCommandService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskCommandService.java
@@ -4,8 +4,8 @@ import com.todo.cateogry.domain.Category;
 import com.todo.cateogry.service.CategoryQueryService;
 import com.todo.task.dto.TaskCreateRequest;
 import com.todo.task.dto.TaskResponse;
+import com.todo.task.dto.TaskUpdateRequest;
 import com.todo.task.entity.Task;
-import com.todo.task.entity.TaskStatus;
 import com.todo.task.entity.repository.TaskRepository;
 import com.todo.task.mapper.TaskMapper;
 import com.todo.user.domain.User;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class TaskCommandService {
 
     private final TaskRepository taskRepository;
+    private final TaskQueryService taskQueryService;
     private final UserDomainService userDomainService;
     private final CategoryQueryService categoryQueryService;
     private final TaskMapper taskMapper;
@@ -32,6 +33,21 @@ public class TaskCommandService {
 
         taskRepository.save(task);
         return taskMapper.entityToTaskResponse(task);
+    }
+
+    public TaskResponse updateTask(Long userId, TaskUpdateRequest request) {
+        Task findTask = taskQueryService.findById(request.getTaskId());
+        findTask.validateOwner(userId);
+
+        findTask.taskUpdate(
+                request.getTitle(),
+                request.getContent(),
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getStatus()
+        );
+
+        return taskMapper.entityToTaskResponse(findTask);
     }
 
 }

--- a/backend/src/main/java/com/todo/task/service/TaskCommandService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskCommandService.java
@@ -24,7 +24,7 @@ public class TaskCommandService {
 
     public TaskResponse createTask(Long userId, TaskCreateRequest request) {
         User findUser = userDomainService.findUserById(userId);
-        Category findCategory = categoryQueryService.findById(request.getCategoryId());
+        Category findCategory = categoryQueryService.findByIdAndUserId(request.getCategoryId(), userId);
 
         Task task = taskMapper.taskCreateRequestToEntity(request);
         task.setUser(findUser);

--- a/backend/src/main/java/com/todo/task/service/TaskCommandService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskCommandService.java
@@ -1,0 +1,41 @@
+package com.todo.task.service;
+
+import com.todo.cateogry.domain.Category;
+import com.todo.cateogry.service.CategoryQueryService;
+import com.todo.task.dto.TaskCreateRequest;
+import com.todo.task.dto.TaskResponse;
+import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
+import com.todo.task.entity.repository.TaskRepository;
+import com.todo.user.domain.User;
+import com.todo.user.service.UserDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TaskCommandService {
+
+    private final TaskRepository taskRepository;
+    private final UserDomainService userDomainService;
+    private final CategoryQueryService categoryQueryService;
+
+    public TaskResponse createTask(Long userId, TaskCreateRequest request) {
+        User findUser = userDomainService.findUserById(userId);
+        Category category = categoryQueryService.findById(request.getCategoryId());
+
+        Task task = Task.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .status(TaskStatus.valueOf(request.getStatus()))
+                .user(findUser)
+                .category(category)
+                .build();
+
+        taskRepository.save(task);
+        return new TaskResponse(category.getId(), task.getTitle(), task.getContent(), task.getStatus(), task.getStartDate(), task.getEndDate());
+    }
+
+}

--- a/backend/src/main/java/com/todo/task/service/TaskCommandService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskCommandService.java
@@ -7,6 +7,7 @@ import com.todo.task.dto.TaskResponse;
 import com.todo.task.entity.Task;
 import com.todo.task.entity.TaskStatus;
 import com.todo.task.entity.repository.TaskRepository;
+import com.todo.task.mapper.TaskMapper;
 import com.todo.user.domain.User;
 import com.todo.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
@@ -19,23 +20,18 @@ public class TaskCommandService {
     private final TaskRepository taskRepository;
     private final UserDomainService userDomainService;
     private final CategoryQueryService categoryQueryService;
+    private final TaskMapper taskMapper;
 
     public TaskResponse createTask(Long userId, TaskCreateRequest request) {
         User findUser = userDomainService.findUserById(userId);
-        Category category = categoryQueryService.findById(request.getCategoryId());
+        Category findCategory = categoryQueryService.findById(request.getCategoryId());
 
-        Task task = Task.builder()
-                .title(request.getTitle())
-                .content(request.getContent())
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
-                .status(TaskStatus.valueOf(request.getStatus()))
-                .user(findUser)
-                .category(category)
-                .build();
+        Task task = taskMapper.taskCreateRequestToEntity(request);
+        task.setUser(findUser);
+        task.setCategory(findCategory);
 
         taskRepository.save(task);
-        return new TaskResponse(category.getId(), task.getTitle(), task.getContent(), task.getStatus(), task.getStartDate(), task.getEndDate());
+        return taskMapper.entityToTaskResponse(task);
     }
 
 }

--- a/backend/src/main/java/com/todo/task/service/TaskCommandService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskCommandService.java
@@ -50,4 +50,10 @@ public class TaskCommandService {
         return taskMapper.entityToTaskResponse(findTask);
     }
 
+    public void deleteTask(Long userId, Long taskId) {
+        Task findTask = taskQueryService.findById(taskId);
+        findTask.validateOwner(userId);
+        taskRepository.delete(findTask);
+    }
+
 }

--- a/backend/src/main/java/com/todo/task/service/TaskQueryService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskQueryService.java
@@ -1,0 +1,22 @@
+package com.todo.task.service;
+
+import static com.todo.common.exception.ErrorCode.TASK_NOT_FOUND;
+
+import com.todo.task.entity.Task;
+import com.todo.task.entity.repository.TaskRepository;
+import com.todo.task.exception.TaskException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TaskQueryService {
+
+    private final TaskRepository taskRepository;
+
+    public Task findById(Long taskId) {
+        return taskRepository.findTaskById(taskId)
+                .orElseThrow(() -> new TaskException(TASK_NOT_FOUND));
+    }
+
+}

--- a/backend/src/main/java/com/todo/task/service/TaskQueryService.java
+++ b/backend/src/main/java/com/todo/task/service/TaskQueryService.java
@@ -2,9 +2,16 @@ package com.todo.task.service;
 
 import static com.todo.common.exception.ErrorCode.TASK_NOT_FOUND;
 
+import com.todo.auth.domain.Auth;
+import com.todo.task.dto.TaskResponse;
+import com.todo.task.dto.TaskSearchRequest;
 import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
 import com.todo.task.entity.repository.TaskRepository;
 import com.todo.task.exception.TaskException;
+import com.todo.task.mapper.TaskMapper;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +20,26 @@ import org.springframework.stereotype.Service;
 public class TaskQueryService {
 
     private final TaskRepository taskRepository;
+    private final TaskMapper taskMapper;
+
+    public List<TaskResponse> findAll(Long userId, TaskSearchRequest request) {
+
+        List<Task> tasks = taskRepository.search(
+                userId,
+                request.getCategoryId(),
+                request.getStartDate(),
+                request.getEndDate(),
+                TaskStatus.from(request.getStatus())
+        );
+
+        List<TaskResponse> result = new ArrayList<>();
+
+        for (Task task : tasks) {
+            result.add(taskMapper.entityToTaskResponse(task));
+        }
+
+        return result;
+    }
 
     public Task findById(Long taskId) {
         return taskRepository.findTaskById(taskId)

--- a/backend/src/test/java/com/todo/BackendApplicationTests.java
+++ b/backend/src/test/java/com/todo/BackendApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class BackendApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
 }

--- a/backend/src/test/java/com/todo/task/service/TaskCommandServiceTest.java
+++ b/backend/src/test/java/com/todo/task/service/TaskCommandServiceTest.java
@@ -1,0 +1,105 @@
+package com.todo.task.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.todo.cateogry.domain.Category;
+import com.todo.cateogry.service.CategoryQueryService;
+import com.todo.task.dto.TaskCreateRequest;
+import com.todo.task.dto.TaskResponse;
+import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
+import com.todo.task.entity.repository.TaskRepository;
+import com.todo.user.domain.User;
+import com.todo.user.service.UserDomainService;
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TaskCommandServiceTest {
+
+    @Mock
+    TaskRepository taskRepository;
+
+    @Mock
+    UserDomainService userDomainService;
+
+    @Mock
+    CategoryQueryService categoryQueryService;
+
+    @InjectMocks
+    TaskCommandService taskCommandService;
+
+    User user;
+    Category category;
+    String email;
+    String password;
+    String confirmPassword;
+
+    @BeforeEach
+    void beforeEach() {
+        this.email = "user@gmail.com";
+        this.password = "user1234";
+        this.confirmPassword = "user1234";
+
+        user = User.builder()
+                .id(1L)
+                .email(email)
+                .password(password)
+                .build();
+
+        category = Category.builder()
+                .id(1L)
+                .name("WORK")
+                .user(user)
+                .build();
+    }
+
+    @Test
+    @DisplayName("사용자는 자신의 카테고리에 Task를 생성할 수 있다.")
+    void 할일_생성_성공() {
+        //given
+        TaskCreateRequest req = new TaskCreateRequest(
+                category.getId(),
+                "테스트 코드 작성하기",
+                "TaskService 테스트 코드 작성하자.",
+                "NONE",
+                LocalDate.now(),
+                LocalDate.now()
+        );
+
+        Task task = Task.builder()
+                .id(1L)
+                .title(req.getTitle())
+                .content(req.getContent())
+                .status(TaskStatus.NONE)
+                .startDate(req.getStartDate())
+                .endDate(req.getEndDate())
+                .user(user)
+                .category(category)
+                .build();
+
+        when(categoryQueryService.findById(1L)).thenReturn(category);
+        when(taskRepository.save(any())).thenReturn(task);
+
+        //when
+        TaskResponse response = taskCommandService.createTask(user.getId(), req);
+
+        //then
+        Assertions.assertThat(response.getTitle()).isEqualTo(req.getTitle());
+        Assertions.assertThat(response.getContent()).isEqualTo(req.getContent());
+        Assertions.assertThat(response.getCategoryId()).isEqualTo(req.getCategoryId());
+        Assertions.assertThat(response.getStartDate()).isEqualTo(req.getStartDate());
+        Assertions.assertThat(response.getEndDate()).isEqualTo(req.getEndDate());
+        Assertions.assertThat(response.getStatus()).isEqualTo(TaskStatus.NONE);
+    }
+
+}

--- a/backend/src/test/java/com/todo/task/service/TaskCommandServiceTest.java
+++ b/backend/src/test/java/com/todo/task/service/TaskCommandServiceTest.java
@@ -2,6 +2,7 @@ package com.todo.task.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.todo.cateogry.domain.Category;
@@ -11,6 +12,7 @@ import com.todo.task.dto.TaskResponse;
 import com.todo.task.entity.Task;
 import com.todo.task.entity.TaskStatus;
 import com.todo.task.entity.repository.TaskRepository;
+import com.todo.task.mapper.TaskMapper;
 import com.todo.user.domain.User;
 import com.todo.user.service.UserDomainService;
 import java.time.LocalDate;
@@ -31,6 +33,9 @@ class TaskCommandServiceTest {
 
     @Mock
     UserDomainService userDomainService;
+
+    @Mock
+    TaskMapper taskMapper;
 
     @Mock
     CategoryQueryService categoryQueryService;
@@ -64,9 +69,9 @@ class TaskCommandServiceTest {
     }
 
     @Test
-    @DisplayName("사용자는 자신의 카테고리에 Task를 생성할 수 있다.")
+    @DisplayName("사용자는 자신의 카테고리에 Task를 생성할 수 있다")
     void 할일_생성_성공() {
-        //given
+        // given
         TaskCreateRequest req = new TaskCreateRequest(
                 category.getId(),
                 "테스트 코드 작성하기",
@@ -87,19 +92,31 @@ class TaskCommandServiceTest {
                 .category(category)
                 .build();
 
-        when(categoryQueryService.findById(1L)).thenReturn(category);
-        when(taskRepository.save(any())).thenReturn(task);
+        TaskResponse resp = new TaskResponse(
+                task.getId(),
+                task.getTitle(),
+                task.getContent(),
+                task.getStatus(),
+                task.getStartDate(),
+                task.getEndDate()
+        );
 
-        //when
-        TaskResponse response = taskCommandService.createTask(user.getId(), req);
+        when(userDomainService.findUserById(user.getId())).thenReturn(user);
+        when(categoryQueryService.findById(category.getId())).thenReturn(category);
+        when(taskMapper.taskCreateRequestToEntity(req)).thenReturn(task);
+        when(taskRepository.save(any(Task.class))).thenReturn(task);
+        when(taskMapper.entityToTaskResponse(task)).thenReturn(resp);
 
-        //then
-        Assertions.assertThat(response.getTitle()).isEqualTo(req.getTitle());
-        Assertions.assertThat(response.getContent()).isEqualTo(req.getContent());
-        Assertions.assertThat(response.getCategoryId()).isEqualTo(req.getCategoryId());
-        Assertions.assertThat(response.getStartDate()).isEqualTo(req.getStartDate());
-        Assertions.assertThat(response.getEndDate()).isEqualTo(req.getEndDate());
-        Assertions.assertThat(response.getStatus()).isEqualTo(TaskStatus.NONE);
+        // when
+        TaskResponse result = taskCommandService.createTask(user.getId(), req);
+
+        // then
+        Assertions.assertThat(result.getTitle()).isEqualTo(req.getTitle());
+        Assertions.assertThat(result.getContent()).isEqualTo(req.getContent());
+        Assertions.assertThat(result.getCategoryId()).isEqualTo(req.getCategoryId());
+        Assertions.assertThat(result.getStartDate()).isEqualTo(req.getStartDate());
+        Assertions.assertThat(result.getEndDate()).isEqualTo(req.getEndDate());
+        Assertions.assertThat(result.getStatus()).isEqualTo(TaskStatus.NONE);
     }
 
 }

--- a/backend/src/test/java/com/todo/task/service/TaskCommandServiceTest.java
+++ b/backend/src/test/java/com/todo/task/service/TaskCommandServiceTest.java
@@ -1,12 +1,15 @@
 package com.todo.task.service;
 
+import static com.todo.common.exception.ErrorCode.CATEGORY_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.todo.cateogry.domain.Category;
+import com.todo.cateogry.exception.CategoryException;
 import com.todo.cateogry.service.CategoryQueryService;
+import com.todo.common.exception.ErrorCode;
 import com.todo.task.dto.TaskCreateRequest;
 import com.todo.task.dto.TaskResponse;
 import com.todo.task.entity.Task;
@@ -117,6 +120,28 @@ class TaskCommandServiceTest {
         Assertions.assertThat(result.getStartDate()).isEqualTo(req.getStartDate());
         Assertions.assertThat(result.getEndDate()).isEqualTo(req.getEndDate());
         Assertions.assertThat(result.getStatus()).isEqualTo(TaskStatus.NONE);
+    }
+
+    @Test
+    @DisplayName("카테고리가 없거나 다른 사용자의 카테고리 PK에 할일을 생성하면 예외가 발생한다.")
+    void 할일_생성_실패_카테고리_없음() {
+        // given
+        TaskCreateRequest req = new TaskCreateRequest(
+                999L,
+                "테스트 코드 작성하기",
+                "TaskService 테스트 코드 작성하자.",
+                "NONE",
+                LocalDate.now(),
+                LocalDate.now()
+        );
+
+        when(categoryQueryService.findByIdAndUserId(any(), any())).thenThrow(new CategoryException(CATEGORY_NOT_FOUND));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> taskCommandService.createTask(user.getId(), req))
+                .isInstanceOf(CategoryException.class)
+                .hasMessage(CATEGORY_NOT_FOUND.getMessage());
+
     }
 
 }

--- a/backend/src/test/java/com/todo/task/service/TaskQueryServiceTest.java
+++ b/backend/src/test/java/com/todo/task/service/TaskQueryServiceTest.java
@@ -1,0 +1,55 @@
+package com.todo.task.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.todo.task.entity.Task;
+import com.todo.task.entity.TaskStatus;
+import com.todo.task.entity.repository.TaskRepository;
+import com.todo.task.mapper.TaskMapper;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TaskQueryServiceTest {
+
+    @Mock
+    TaskRepository taskRepository;
+
+    @Mock
+    TaskMapper taskMapper;
+
+    @InjectMocks
+    TaskQueryService taskQueryService;
+
+
+    @Test
+    @DisplayName("Task의 고유한 ID로 Task를 조회할 수 있다.")
+    void 할일_검색_성공() {
+        //given
+        Task task = Task.builder()
+                .id(1L)
+                .title("TaskService 테스트 코드 작성")
+                .content("Hello world")
+                .status(TaskStatus.PROGRESS)
+                .build();
+
+        when(taskRepository.findTaskById(1L)).thenReturn(Optional.of(task));
+
+        //when
+        Task findTask = taskQueryService.findById(1L);
+
+        //then
+        assertThat(task.getId()).isEqualTo(findTask.getId());
+        assertThat(task.getTitle()).isEqualTo(findTask.getTitle());
+        assertThat(task.getStatus()).isEqualTo(TaskStatus.PROGRESS);
+    }
+
+}

--- a/backend/src/test/java/com/todo/task/service/TaskQueryServiceTest.java
+++ b/backend/src/test/java/com/todo/task/service/TaskQueryServiceTest.java
@@ -2,19 +2,31 @@ package com.todo.task.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.todo.task.dto.TaskResponse;
+import com.todo.task.dto.TaskSearchRequest;
 import com.todo.task.entity.Task;
 import com.todo.task.entity.TaskStatus;
 import com.todo.task.entity.repository.TaskRepository;
 import com.todo.task.mapper.TaskMapper;
+import com.todo.user.domain.User;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +62,70 @@ class TaskQueryServiceTest {
         assertThat(task.getId()).isEqualTo(findTask.getId());
         assertThat(task.getTitle()).isEqualTo(findTask.getTitle());
         assertThat(task.getStatus()).isEqualTo(TaskStatus.PROGRESS);
+    }
+
+    @Test
+    @DisplayName("검색 조건대로 Task를 조회하고 Mapper로 변환해 리스트를 반환한다")
+    void 할일_검색_필터링_성공() {
+        // given
+        User user = User.builder().id(1L).build();
+
+        List<Task> tasks = new ArrayList<>();
+        LocalDate start = LocalDate.of(2025, 8, 20);
+        for (long i = 1L; i <= 10L; i++) {
+            tasks.add(Task.builder()
+                    .id(i)
+                    .user(user)
+                    .status(TaskStatus.NONE)
+                    .startDate(start)
+                    .endDate(start.plusDays(i))
+                    .build());
+        }
+
+        TaskSearchRequest req =
+                new TaskSearchRequest(1L, "NONE", LocalDate.now(), LocalDate.now());
+
+        try (MockedStatic<TaskStatus> mocked = mockStatic(TaskStatus.class)) {
+            mocked.when(() -> TaskStatus.from("NONE"))
+                    .thenReturn(TaskStatus.NONE);
+
+            when(taskRepository.search(
+                    eq(user.getId()),
+                    eq(req.getCategoryId()),
+                    eq(req.getStartDate()),
+                    eq(req.getEndDate()),
+                    eq(TaskStatus.NONE)
+            )).thenReturn(tasks);
+
+            when(taskMapper.entityToTaskResponse(any(Task.class))).thenAnswer(inv -> {
+                Task t = inv.getArgument(0);
+                return new TaskResponse(
+                        t.getId(),
+                        null,
+                        null,
+                        t.getStatus(),
+                        t.getStartDate(),
+                        t.getEndDate()
+                );
+            });
+
+            // when
+            List<TaskResponse> all = taskQueryService.findAll(user.getId(), req);
+
+            // then
+            assertThat(all).hasSize(10);
+
+            verify(taskRepository).search(
+                    user.getId(),
+                    req.getCategoryId(),
+                    req.getStartDate(),
+                    req.getEndDate(),
+                    TaskStatus.NONE
+            );
+
+            verify(taskMapper, times(10)).entityToTaskResponse(any(Task.class));
+            verifyNoMoreInteractions(taskRepository, taskMapper);
+        }
     }
 
 }


### PR DESCRIPTION
### 목표
- 사용자는 자신이 생성한 카테고리에 할 일(Task)를 생성하고 관리할 수 있다.

### 구현 목록
- [x] Task 엔티티 생성
- [x] TaskRepository 생성
- [x] Task CURD 기능 구현 및 DTO 생성
   - [x] 시작일, 종료일, 상태를 필터링하여 검색할 수 있는 기능 구현
- [x] 인가 기능 구현
- [x] Task API 엔드포인트 구현